### PR TITLE
Perform update skipped the update when tabbar disappeared

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -1553,8 +1553,7 @@ static NSMutableDictionary *registeredStyleClasses = nil;
             [self hideTabBar:NO animate:animate];
         else if (![self _shouldDisplayTabBar]) {
             [self hideTabBar:YES animate:animate];
-            [self setNeedsUpdate:NO];
-            return;
+            animate = NO;
         }
     }
 
@@ -1562,7 +1561,7 @@ static NSMutableDictionary *registeredStyleClasses = nil;
         // go through buttons, remove any whose tab view items are not in [_tabView tabViewItems]
     NSSet *attachedButtons = [self attachedButtons];
     for (MMAttachedTabBarButton *aButton in attachedButtons) {
-            //remove the observer binding
+        //remove the observer binding
 		if ([aButton tabViewItem] && ![tabItems containsObject:[aButton tabViewItem]]) {
 			if ([[self delegate] respondsToSelector:@selector(tabView:didDetachTabViewItem:)]) {
 				[[self delegate] tabView:_tabView didDetachTabViewItem:[aButton tabViewItem]];


### PR DESCRIPTION
In my testing this was the cause and fixed the missing deallocation of the last tab bar item of the tabbar. The remaining tabbar item caused the browserpane to be retained.