### PR TITLE
Fix freeze on entering full screen window mode

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -211,10 +211,6 @@ static NSMutableDictionary<NSString*, Class <MMTabStyle>> *registeredStyleClasse
 }
 
 -(void)viewDidEndLiveResize {
-    for (MMAttachedTabBarButton *aButton in self.attachedButtons) {
-		[aButton.indicator startAnimation:self];
-	}
-
 	[self _checkWindowFrame];
 	[self update:NO];
 }


### PR DESCRIPTION
On macOS Mojave, window freezes when entering full screen window mode.
If the window is frozen, clicking outside the app allows it to complete
the transition to full screen mode. So even just clicking on another
icon in the Dock allows it to continue (Issue MiMo42/MMTabBarView#63).

Brendan Duddridge (@brendand) noticed that the problem has to do with
MMTabBarView’s -viewDidEndLiveResize. Removing the animation works
around it.