### PR TITLE
Add missing header to SPM public header and insert NSBundle macro

### DIFF
--- a/MMTabBarView/MMTabBarView/MMOverflowPopUpButton.m
+++ b/MMTabBarView/MMTabBarView/MMOverflowPopUpButton.m
@@ -9,18 +9,9 @@
 #import "MMOverflowPopUpButton.h"
 
 #import "MMOverflowPopUpButtonCell.h"
-// #import "MMTabBarView.h"
+#import "MMTabBarView.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-#define StaticImage(name) \
-static NSImage* _static##name##Image() \
-{ \
-    static NSImage* image = nil; \
-    if (!image) \
-		image = [[NSBundle bundleForClass:MMOverflowPopUpButtonCell.class] imageForResource:@#name]; \
-    return image; \
-}
 
 @interface MMOverflowPopUpButton ()
 

--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -258,7 +258,11 @@ static NSMutableDictionary<NSString*, Class <MMTabStyle>> *registeredStyleClasse
 {
 	static NSBundle *bundle = nil;
 	if (!bundle) {
-		bundle = [NSBundle bundleForClass:MMTabBarView.class];
+#ifdef SWIFTPM_MODULE_BUNDLE
+        bundle = SWIFTPM_MODULE_BUNDLE;
+#else
+        bundle = [NSBundle bundleForClass:MMTabBarView.class];
+#endif
 	}
 	return bundle;
 }

--- a/MMTabBarView/MMTabBarView/include/MMTarBarStyle-SPM.h
+++ b/MMTabBarView/MMTabBarView/include/MMTarBarStyle-SPM.h
@@ -25,6 +25,7 @@
 #import "../MMTabBarButtonCell.h"
 #import "../MMTabBarItem.h"
 #import "../MMTabBarView.Globals.h"
+#import "../MMTabBarView.h"
 #import "../MMTabStyle.h"
 #import "../MMUnifiedTabStyle.h"
 #import "../MMYosemiteTabStyle.h"

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 let package = Package(
     name: "MMTabBarView",
     defaultLocalization: LanguageTag("en"),
+    platforms: [
+        .macOS(.v10_10),
+    ],
     products: [
         .library(name: "MMTabBarView", targets: ["MMTabBarView"]),
     ],


### PR DESCRIPTION
Swift Package Manager puts image resources into a separate bundle within the Resources directory. It also provides this macro as a shorthand to retrieve the correct NSBundle instance.